### PR TITLE
Add hot module replacement for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/jtiala/reducks-starter"
   },
   "scripts": {
-    "build": "webpack --mode production",
-    "start": "webpack-dev-server --watch --watch-content-base --hot --mode development",
+    "build": "NODE_ENV=prod webpack --mode production",
+    "start": "NODE_ENV=dev webpack-dev-server --watch --watch-content-base --mode development",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,3 +16,7 @@ const Root = () => (
 );
 
 ReactDOM.render(<Root />, document.getElementById('root'));
+
+if (module.hot) {
+  module.hot.accept();
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const flexbugs = require('postcss-flexbugs-fixes');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
@@ -6,7 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = {
+const webpackConfig = {
   entry: ['@babel/polyfill', './src/index.jsx'],
   output: {
     path: path.join(__dirname, '/dist'),
@@ -74,10 +75,17 @@ module.exports = {
     }),
     new MiniCssExtractPlugin({
       filename: 'styles.css',
-    }),
-  ],
-  devServer: {
+    })
+  ]
+};
+
+if (process.env.NODE_ENV === 'dev') {
+  webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
+  webpackConfig.devServer = {
+    hot: true,
     historyApiFallback: true,
     contentBase: path.join(__dirname, 'src/static'),
-  },
-};
+  };
+}
+
+module.exports = webpackConfig;


### PR DESCRIPTION
### Changes made (Addresses issue #1):

* Added `HotModuleReplacementPlugin` and `devServer` configuration in `webpack.config.js` for development mode.
* Updated `index.jsx` to accept hot module replacements.
* Updated `package.json` scripts to set `NODE_ENV` before running `start` and `build` scripts.

### Screen recording:

https://drive.google.com/file/d/1mDJClWHfNUZs5PnR4sTEzOnLfiVhxPqa/view?usp=sharing