### PR TITLE
Use core-js, remove babel polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.6.0",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.5.2",
+    "core-js": "^2.6.9",
     "history": "^4.10.1",
     "immutable": "^4.0.0-rc.12",
     "modern-normalize": "^0.5.0",
@@ -56,7 +56,8 @@
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.4",
     "redux-immutable": "^4.0.0",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const webpackConfig = env => {
   const publicPath = env.PUBLIC_PATH || '/';
 
   const config = {
-    entry: ['@babel/polyfill', './src/index.jsx'],
+    entry: ['./src/index.jsx'],
     output: {
       path: path.resolve(__dirname, 'dist'),
       publicPath,


### PR DESCRIPTION
- Add `core-js` and `regenerator-runtime` dependencies
- Remove `@babel/polyfill` dependency

After this change, I noticed that the bundle is now smaller.
Master branch: core-js: 204kb, total: 868kb
This branch: core-js: 55kb, total: 695kb

I think this is because babel is configured to use `useBuiltIns: 'usage'`.

Resolves #18